### PR TITLE
Add additional file checks to prevent config leaks

### DIFF
--- a/config/apache/apache2.conf
+++ b/config/apache/apache2.conf
@@ -185,6 +185,18 @@ Include ports.conf
     Require all denied
 </Directory>
 
+# Prevent access to the .git dir
+<Directory /var/www/html/.git>
+    AllowOverride None
+    Require all denied
+</Directory>
+
+# Prevent access to the vendor folder
+<Directory /var/www/html/vendor>
+    AllowOverride None
+    Require all denied
+</Directory>
+
 
 
 
@@ -206,6 +218,32 @@ AccessFileName .htaccess
 <FilesMatch "^\.env">
     Require all denied
 </FilesMatch>
+
+# Prevent access to .gitignore files
+<FilesMatch "^\.gitignore">
+    Require all denied
+</FilesMatch>
+
+# Prevents access to composer files
+<FilesMatch "^composer\.(json|lock)">
+    Require all denied
+</FilesMatch>
+
+# Prevents access to any hanging SQL files
+<FilesMatch "^.+\.sql">
+    Require all denied
+</FilesMatch>
+
+# Prevents access to README.md
+<FilesMatch "^README\.md">
+    Require all denied
+</FilesMatch>
+
+# Prevents access to docker-compose.yml
+<FilesMatch "^docker-compose\.yml">
+    Require all denied
+</FilesMatch>
+
 
 #
 # The following directives define some format nicknames for use with


### PR DESCRIPTION
Did some additional checks and we're leaking the following files and directories:

Directories:
- .git
- vendor

Files:
- docker-compose.yml
- .gitignore
- composer.json
- composer.lock
- database.sql
- README.md

Some of these files being exposed like this isn't exactly a major issue since this project is open-sourced and all of this is already visible from the repo but this should still be amended since we shouldn't be serving any of these anyways.