### PR TITLE
Change PHP Docker container to share UID/GID for host's web folder

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -5,3 +5,7 @@ DB_DATABASE="OverseerV2"
 OVERSEER_ROOT="/php/"
 OVERSEER_PHP_SESSIONS_ROOT="/.session/"
 SITE_HOSTNAME=http://localhost
+
+#User ID for PHP file permissions to adopt
+USERID=1000
+GROUPID=1000

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -26,6 +26,8 @@ jobs:
           echo OVERSEER_ROOT="/php/" >> .env
           echo OVERSEER_PHP_SESSIONS_ROOT="/.session/" >> .env
           echo SITE_HOSTNAME=overseerreboot.xyz >> .env
+          echo USERID=1000 >> .env
+          echo GROUPID=1000 >>.env
     - name: 'Run Docker build'
       run: docker compose --profile dev up -d --build
     - name: 'Sleep (wait for the services to spin up properly)'

--- a/config/php/Dockerfile.dev
+++ b/config/php/Dockerfile.dev
@@ -2,6 +2,9 @@ FROM php:8.2-apache-bookworm
 
 WORKDIR /var/www/html/
 
+ARG USER_ID
+ARG GROUP_ID
+
 # Setup sessions directory
 RUN mkdir /var/www/sessions/
 RUN chown -R www-data /var/www/sessions/
@@ -26,6 +29,9 @@ RUN apt-get install -y unzip
 RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-install mysqli
 RUN composer install
+
+RUN usermod -u ${USER_ID} www-data
+RUN groupmod -g ${GROUP_ID} www-data
 
 # Copy php.ini
 COPY ./config/php/dev-php.ini /usr/local/etc/php/php.ini

--- a/config/php/Dockerfile.dev
+++ b/config/php/Dockerfile.dev
@@ -7,7 +7,6 @@ ARG GROUP_ID
 
 # Setup sessions directory
 RUN mkdir /var/www/sessions/
-RUN chown -R www-data /var/www/sessions/
 
 # Setup composer
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
@@ -30,6 +29,7 @@ RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-install mysqli
 RUN composer install
 
+# Align file permissions to the host's expectations
 RUN usermod -u ${USER_ID} www-data
 RUN groupmod -g ${GROUP_ID} www-data
 

--- a/config/php/setup.sh
+++ b/config/php/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 composer install
-chown -R www-data:www-data /var/www
 mkdir -p /var/www/html/logs/
+#this needs to go in setup.sh because RUN chown doesn't play nice with volumes
+chown -R www-data:www-data /var/www
 /usr/sbin/apache2ctl -D FOREGROUND

--- a/config/php/setup.sh
+++ b/config/php/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 composer install
+chown -R www-data:www-data /var/www
 mkdir -p /var/www/html/logs/
 /usr/sbin/apache2ctl -D FOREGROUND

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,9 @@ services:
     profiles:
       - dev
     build:
+      args:
+        USER_ID: ${USERID}
+        GROUP_ID: ${GROUPID}
       dockerfile: ./config/php/Dockerfile.dev
     volumes:
       - ./php/:/var/www/html/


### PR DESCRIPTION
This is a fix for permissions issues that crop up due to the way the containers use volumes to load Overseer code.
Previously, due to how Docker volumes work, the unix permissions from the host filesystem would reflect in the container, and vice versa for any changes by the container. This resulted in permissions errors, as it is expected these folders are owned by www-data.

The easiest fix I could find is to have the container set the UID of www-data to a configurable number (intended to be the UID of the host). Same permissions, different interpretations for both host and container.

Also fixed the github actions script to reflect my changes to .env.